### PR TITLE
feat: Insertion Sort | fix: testSort() out-of-index

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 * If you want to change the maximum array size or the number of arrays, please modify ARRAY_SIZE and MAX_NUMBER in ```sort.h```
 
-* To toggle the array-printing feature, please modify ```PRINT_ARRAY``` in ```main.h```
+* To toggle the array-printing feature, please modify ```PRINT_ARRAY``` in ```sort.h```
 * To select which sorting algorithms to execute, modify ```isSortingEnabled``` in ```main.cpp```
 
 ### How to build
@@ -21,7 +21,7 @@ make clean
 - [X] Selection Sort
 - [X] Quick Sort
 - [ ] Heap Sort
-- [ ] Insertion Sort
+- [X] Insertion Sort
 - [ ] Merge Sort
 - [ ] Shell Sort
 - [ ] Radix Sort

--- a/main.cpp
+++ b/main.cpp
@@ -9,11 +9,11 @@ int main(){
     // false: Algorithm is disabled and will be skipped.
 
     bool isSortingEnabled[NUM_SORTS] = {
-        true,           // Bubble Sort
+        false,           // Bubble Sort
         false,           // Selection Sort
-        true,           // Quick Sort
+        false,           // Quick Sort
         false,          // Heap Sort
-        false,          // Insertion Sort
+        true,          // Insertion Sort
         false,          // Merge Sort
         false,          // Shell Sort
         false,          // Radix Sort
@@ -49,7 +49,7 @@ int main(){
 
         // Code about Progress Bar
         cout << (iter * 100 / ITERATION_SIZE) << "% ["; 
-        for (int progressBar = 0; progressBar < (iter * 100 / ITERATION_SIZE) / 5 ; progressBar++){
+        for (int progressBar = 1; progressBar < (iter * 100 / ITERATION_SIZE) / 5 ; progressBar++){
             cout << "=";
         }
         cout << ">";

--- a/main.h
+++ b/main.h
@@ -3,15 +3,5 @@
 
 #define NUM_SORTS 9
 
-//-------[EDIT THIS]-------/
-#define ITERATION_SIZE 1000
-
-// when PRINT_ARRAY is defined as true, the {best, worst} array is printed.
-// when PRINT_ARRAY is defined as false, this feature is disabled
-
-#define PRINT_ARRAY false
-
-//-------------------------/
-
 int main();
 void genRandomArr(int* arr);

--- a/sort.cpp
+++ b/sort.cpp
@@ -18,6 +18,10 @@ int sort(int sortIdx, int arr[ARRAY_SIZE]){
             quickSort(arr, 0, ARRAY_SIZE-1);
             break;
         }
+        case 4: {
+            insertionSort(arr);
+            break;
+        }
 
         default: {
             return -1;
@@ -36,11 +40,13 @@ int sort(int sortIdx, int arr[ARRAY_SIZE]){
     }
     else {
         cerr << "Warning : The array is not sorted correctly." << endl;
-        cout << "[";
-        for(int i=0;i<ARRAY_SIZE;i++) {
-            cout << arr[i] << " ";
+        if(PRINT_ARRAY == true){
+            cout << "[";
+            for(int i=0;i<ARRAY_SIZE;i++) {
+                cout << arr[i] << ", ";
+            }
+            cout << "]";    
         }
-        cout << "]";
         return -1;
     }
 }
@@ -103,6 +109,21 @@ void quickSort(int arr[ARRAY_SIZE], int low, int high){
 
 }
 
+void insertionSort(int arr[ARRAY_SIZE]){
+    int i, j, key;
+    for(i=1;i<ARRAY_SIZE;i++) {
+        key = arr[i];
+
+        for(j=i-1; j>=0 && arr[j] > key; j--){
+            arr[j+1] = arr[j];
+        }
+        arr[j+1] = key;
+    }   
+}
+
+
+//-----------
+
 int selectPivotIdx(int arr[ARRAY_SIZE], int low, int high){
     int p1 = arr[low];
     int p2 = arr[high];
@@ -121,12 +142,12 @@ void swap(int& p1, int& p2) {
 }
 
 bool testSort(int arr[ARRAY_SIZE]){
-    for(int i=0;i<ARRAY_SIZE;i++){
+    for(int i=0;i<ARRAY_SIZE-1;i++){
         if(arr[i] > arr[i+1]){
             // not sorted correctly
+            cout << "[?] idx " << i << ": " << arr[i] << ", idx " << i+1 << ": " << arr[i+1] << endl;
             return false;
         }
-        
     }
     return true;
 }

--- a/sort.h
+++ b/sort.h
@@ -7,6 +7,13 @@
 //-------[EDIT THIS]-------/
 #define ARRAY_SIZE 6000
 #define MAX_NUMBER 10000
+#define ITERATION_SIZE 1000
+
+// when PRINT_ARRAY is defined as true, the {best, worst} array is printed.
+// when PRINT_ARRAY is defined as false, this feature is disabled
+
+#define PRINT_ARRAY false
+
 //-------------------------/
 
 using namespace std;
@@ -84,6 +91,8 @@ int sort(int sortIdx, int arr[ARRAY_SIZE]);
 void bubbleSort(int arr[ARRAY_SIZE]);
 void selectionSort(int arr[ARRAY_SIZE]);
 void quickSort(int arr[ARRAY_SIZE], int low, int high);
+
+void insertionSort(int arr[ARRAY_SIZE]);
 
 
 // lemma things


### PR DESCRIPTION
* 삽입 정렬 기능을 추가하였습니다.
* 정렬 기능 추가 후 테스트 과정에서, testSort()에서 arr[ARRAY_SIZE]로 잘못 접근하여 
sort test를 정상적으로 수행하지 못하는 버그를 확인하였고, 이를 수정하였습니다.
* PRINT_ARRAY를 testSort()에서도 사용하기 위해 이 define을 sort.h로 옮겼습니다.
* ITERATION_SIZE 또한 sort.h로 옮겼습니다.
